### PR TITLE
Check for null or undefined explicitly when coercing

### DIFF
--- a/signal-element.js
+++ b/signal-element.js
@@ -33,7 +33,7 @@ function effect(callback) {
 }
 
 function coerce(value) {
-	if (!value) return;
+	if (value === null || value === undefined) return;
 	if (value === 'false' || value === 'true') return value === 'true';
 	if (!isNaN(Number(value))) return Number(value);
 	try {


### PR DESCRIPTION
I think you would want to check for `null` or `undefined` explicitly, otherwise a state of `0` won't get coerced into a number as expected.