### PR TITLE
Override `render` instead of using `customRenderer`

### DIFF
--- a/signal-element.js
+++ b/signal-element.js
@@ -67,7 +67,11 @@ class SignalElement extends HTMLElement {
 	_render() {
 		const value = this.mutation(this.signal.get());
 		if (this.isHTML) {
-			this.innerHTML = value;
+			if (this.render !== undefined) {
+				this.innerHTML = this.render(value);
+			} else {
+				this.innerHTML = value;
+			}
 		} else {
 			this.textContent = `${value}`;
 		}

--- a/signal-element.js
+++ b/signal-element.js
@@ -67,11 +67,7 @@ class SignalElement extends HTMLElement {
 	_render() {
 		const value = this.mutation(this.signal.get());
 		if (this.isHTML) {
-			if (this.render !== undefined) {
-				this.setHTMLUnsafe(this.render(value));
-			} else {
-				this.setHTMLUnsafe(value);
-			}
+			this.setHTMLUnsafe(value);
 		} else {
 			this.textContent = `${value}`;
 		}

--- a/signal-element.js
+++ b/signal-element.js
@@ -50,7 +50,7 @@ function coerce(value) {
 class SignalElement extends HTMLElement {
 	constructor() {
 		super();
-		this.isHTML = this.getAttribute('render') === 'html';
+		this.isHTML = this.getAttribute('render') === 'html' || this.render !== undefined;
 		this.mutation = (state) => state;
 		const initial = this.isHTML
 			? coerce(this.getAttribute('state')) || this.innerHTML

--- a/signal-element.js
+++ b/signal-element.js
@@ -56,15 +56,15 @@ class SignalElement extends HTMLElement {
 			? coerce(this.getAttribute('state')) || this.innerHTML
 			: coerce(this.getAttribute('state')) || coerce(this.textContent);
 		this.signal = new Signal.State(initial);
-		this.cleanup = effect(() => this.render());
+		this.cleanup = effect(() => this._render());
 	}
 	connectedCallback() {
-		this.render();
+		this._render();
 	}
 	disconnectedCallback() {
 		this.cleanup();
 	}
-	render() {
+	_render() {
 		const value = this.mutation(this.signal.get());
 		if (this.isHTML) {
 			this.innerHTML = value;
@@ -72,20 +72,23 @@ class SignalElement extends HTMLElement {
 			this.textContent = `${value}`;
 		}
 	}
+	render() {
+		return this._render();
+	}
 	get state() {
 		return this.signal.get();
 	}
 	set state(v) {
 		this.signal.set(v);
 	}
-	set customRenderer(callback) {
+	set render(callback) {
 		this.mutation = callback;
-		this.render();
+		this._render();
 	}
 	set computed(callback) {
 		this.cleanup();
 		this.signal = new Signal.Computed(callback);
-		this.cleanup = effect(() => this.render());
+		this.cleanup = effect(() => this._render());
 	}
 }
 

--- a/signal-element.js
+++ b/signal-element.js
@@ -50,7 +50,7 @@ function coerce(value) {
 class SignalElement extends HTMLElement {
 	constructor() {
 		super();
-		this.isHTML = this.getAttribute('render') === 'html' || this.render !== undefined;
+		this.isHTML = this.getAttribute('render') === 'html';
 		this.mutation = (state) => state;
 		const initial = this.isHTML
 			? coerce(this.getAttribute('state')) || this.innerHTML

--- a/signal-element.js
+++ b/signal-element.js
@@ -68,9 +68,9 @@ class SignalElement extends HTMLElement {
 		const value = this.mutation(this.signal.get());
 		if (this.isHTML) {
 			if (this.render !== undefined) {
-				this.innerHTML = this.render(value);
+				this.setHTMLUnsafe(this.render(value));
 			} else {
-				this.innerHTML = value;
+				this.setHTMLUnsafe(value);
 			}
 		} else {
 			this.textContent = `${value}`;

--- a/signal-element.js
+++ b/signal-element.js
@@ -72,9 +72,6 @@ class SignalElement extends HTMLElement {
 			this.textContent = `${value}`;
 		}
 	}
-	render() {
-		return this._render();
-	}
 	get state() {
 		return this.signal.get();
 	}


### PR DESCRIPTION
Based on
<img width="754" alt="Screenshot 2024-12-31 at 8 03 43 PM" src="https://github.com/user-attachments/assets/2579c7d3-3023-4103-b6e4-a1855e36d40d" />

I was wondering if overriding a `render` method might be better DX? I don't love `_render`, but just trying to signify that it's the internal method. Just trying out different approaches!
