### PR TITLE
Switch out `innerHTML` with `getHTML`

### DIFF
--- a/signal-element.js
+++ b/signal-element.js
@@ -1,0 +1,92 @@
+import { Signal } from 'https://www.unpkg.com/signal-polyfill@0.2.1/dist/index.js';
+
+let needsEnqueue = true;
+
+const w = new Signal.subtle.Watcher(() => {
+	if (needsEnqueue) {
+		needsEnqueue = false;
+		queueMicrotask(processPending);
+	}
+});
+
+function processPending() {
+	needsEnqueue = true;
+	for (const s of w.getPending()) {
+		s.get();
+	}
+	w.watch();
+}
+
+function effect(callback) {
+	let cleanup;
+	const computed = new Signal.Computed(() => {
+		typeof cleanup === 'function' && cleanup();
+		cleanup = callback();
+	});
+	w.watch(computed);
+	computed.get();
+	return () => {
+		w.unwatch(computed);
+		typeof cleanup === 'function' && cleanup();
+		cleanup = undefined;
+	};
+}
+
+function coerce(value) {
+	if (!value) return;
+	if (value === 'false' || value === 'true') return value === 'true';
+	if (!isNaN(Number(value))) return Number(value);
+	try {
+		const correctedValue = value.replace(/'/g, '"');
+		const parsed = JSON.parse(correctedValue);
+		if (Array.isArray(parsed)) return parsed;
+		if (typeof parsed === 'object') return parsed;
+	} catch (e) {
+		// Not valid JSON, return the original value
+	}
+	return value;
+}
+
+class SignalElement extends HTMLElement {
+	constructor() {
+		super();
+		this.isHTML = this.getAttribute('render') === 'html';
+		this.mutation = (state) => state;
+		const initial = this.isHTML
+			? coerce(this.getAttribute('state')) || this.innerHTML
+			: coerce(this.getAttribute('state')) || coerce(this.textContent);
+		this.signal = new Signal.State(initial);
+		this.cleanup = effect(() => this.render());
+	}
+	connectedCallback() {
+		this.render();
+	}
+	disconnectedCallback() {
+		this.cleanup();
+	}
+	render() {
+		const value = this.mutation(this.signal.get());
+		if (this.isHTML) {
+			this.innerHTML = value;
+		} else {
+			this.textContent = `${value}`;
+		}
+	}
+	get state() {
+		return this.signal.get();
+	}
+	set state(v) {
+		this.signal.set(v);
+	}
+	set customRenderer(callback) {
+		this.mutation = callback;
+		this.render();
+	}
+	set computed(callback) {
+		this.cleanup();
+		this.signal = new Signal.Computed(callback);
+		this.cleanup = effect(() => this.render());
+	}
+}
+
+customElements.define('x-signal', SignalElement);

--- a/signal-element.js
+++ b/signal-element.js
@@ -53,7 +53,7 @@ class SignalElement extends HTMLElement {
 		this.isHTML = this.getAttribute('render') === 'html';
 		this.mutation = (state) => state;
 		const initial = this.isHTML
-			? coerce(this.getAttribute('state')) || this.innerHTML
+			? coerce(this.getAttribute('state')) || this.getHTML()
 			: coerce(this.getAttribute('state')) || coerce(this.textContent);
 		this.signal = new Signal.State(initial);
 		this.cleanup = effect(() => this._render());

--- a/signal-element.js
+++ b/signal-element.js
@@ -33,7 +33,7 @@ function effect(callback) {
 }
 
 function coerce(value) {
-	if (!value) return;
+	if (value === null || value === undefined) return;
 	if (value === 'false' || value === 'true') return value === 'true';
 	if (!isNaN(Number(value))) return Number(value);
 	try {

--- a/signal-element.js
+++ b/signal-element.js
@@ -56,18 +56,18 @@ class SignalElement extends HTMLElement {
 			? coerce(this.getAttribute('state')) || this.innerHTML
 			: coerce(this.getAttribute('state')) || coerce(this.textContent);
 		this.signal = new Signal.State(initial);
-		this.cleanup = effect(() => this.render());
+		this.cleanup = effect(() => this._render());
 	}
 	connectedCallback() {
-		this.render();
+		this._render();
 	}
 	disconnectedCallback() {
 		this.cleanup();
 	}
-	render() {
+	_render() {
 		const value = this.mutation(this.signal.get());
 		if (this.isHTML) {
-			this.innerHTML = value;
+			this.setHTMLUnsafe(value);
 		} else {
 			this.textContent = `${value}`;
 		}
@@ -78,14 +78,14 @@ class SignalElement extends HTMLElement {
 	set state(v) {
 		this.signal.set(v);
 	}
-	set customRenderer(callback) {
+	set render(callback) {
 		this.mutation = callback;
-		this.render();
+		this._render();
 	}
 	set computed(callback) {
 		this.cleanup();
 		this.signal = new Signal.Computed(callback);
-		this.cleanup = effect(() => this.render());
+		this.cleanup = effect(() => this._render());
 	}
 }
 


### PR DESCRIPTION
### Description of changes

Update the `signal-element.js` file to use the more modern `getHTML` API instead of `innerHTML`.