### PR TITLE
Switch `innerHTML` with `getHTML` API

### DIFF
--- a/signal-element.js
+++ b/signal-element.js
@@ -53,7 +53,7 @@ class SignalElement extends HTMLElement {
 		this.isHTML = this.getAttribute('render') === 'html';
 		this.mutation = (state) => state;
 		const initial = this.isHTML
-			? coerce(this.getAttribute('state')) || this.innerHTML
+			? coerce(this.getAttribute('state')) || this.getHTML()
 			: coerce(this.getAttribute('state')) || coerce(this.textContent);
 		this.signal = new Signal.State(initial);
 		this.cleanup = effect(() => this._render());


### PR DESCRIPTION
### Description of changes

Update the `signal-element.js` file to use the more modern `getHTML` API instead of `innerHTML`.
